### PR TITLE
Add info threshold threshold as nextflow parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The configuration for a given run is specified in a run-specific config file, wh
 * BGEN_FILES : absolute path to the BGEN files for your cohort-of-interest. This should be specified using brace expansion for each chromosome as well as each file type (bgen, bgen.bgi, sample).
 * ASSEMBLY : either grch37 or grch38 (also will accept hg19 or hg38), which is used to define problem areas of the genome to exclude (See: https://github.com/gabraham/flashpca/blob/master/exclusion_regions_hg19.txt)
 * R2_THRESHOLD : R-squared threshold to use for idenftifying which SNPs are in LD with one another. Default is 0.8. 
+* INFO_THRESHOLD : Info score threshold set on imputation quality. Anything below this value will not be considered for hard-calling genotypes from the BGEN files. The default is 0.9.
 
 ## Run
 

--- a/genomicc.config
+++ b/genomicc.config
@@ -4,4 +4,5 @@ params {
     BGEN_FILES = "/exports/igmm/eddie/ponting-lab/breeshey/data/genomicc/imputed/genomic-isaric/GenOMICC_ISARIC_chr{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22}.{bgen,bgen.bgi,sample}"
     ASSEMBLY = "grch38"
     R2_THRESHOLD = 0.8
+    INFO_THRESHOLD = 0.6
 }

--- a/py/create_assoc_file.py
+++ b/py/create_assoc_file.py
@@ -63,16 +63,15 @@ if __name__ == '__main__':
                 ref_alleles[i] = ref_allele
                 alt_alleles[i] = alt_allele
 
-    # Add to eqtls
-    eqtls['SNP'] = new_ids
+    eqtls['BGEN_ID'] = new_ids
     eqtls['A1'] = ref_allele
     eqtls['A2'] = alt_allele
 
     # Remove missing values
-    eqtls = eqtls.dropna(subset = ["SNP"])
+    eqtls = eqtls.dropna(subset = ["BGEN_ID"])
 
     # Reformat to match what is expected in PLINK for LD-clumping
-    eqtls = eqtls[["SNP","SNPChr","SNPPos","A1","A2","Pvalue"]]
-    eqtls.columns = ["SNP","CHR","BP","A1","A2","P"]
-
+    eqtls = eqtls[["BGEN_ID","SNP","SNPChr","SNPPos","A1","A2","Pvalue"]]
+    eqtls.columns = ["SNP","RSID","CHR","BP","A1","A2","P"]
+    
     eqtls.to_csv(f"{tf}_ciseQTLs_hg38.assoc", index = False, sep = "\t")

--- a/scripts/4_convert_eQTLGen_SNP_IDs.py
+++ b/scripts/4_convert_eQTLGen_SNP_IDs.py
@@ -46,15 +46,15 @@ for i, snp in enumerate(eqtls.SNP.values):
             alt_alleles[i] = alt_allele
 
 # Add to eqtls
-eqtls['SNP'] = new_ids
+eqtls['BGEN_ID'] = new_ids
 eqtls['A1'] = ref_allele
 eqtls['A2'] = alt_allele
 
 # Remove missing values
-eqtls = eqtls.dropna(subset = ["SNP"])
+eqtls = eqtls.dropna(subset = ["BGEN_ID"])
 
 # Reformat to match what is expected in PLINK for LD-clumping
-eqtls = eqtls[["SNP","SNPChr","SNPPos","A1","A2","Pvalue"]]
-eqtls.columns = ["SNP","CHR","BP","A1","A2","P"]
+eqtls = eqtls[["BGEN_ID","SNP","SNPChr","SNPPos","A1","A2","Pvalue"]]
+eqtls.columns = ["SNP","RSID","CHR","BP","A1","A2","P"]
 
 eqtls.to_csv(f"input/{tf}_ciseQTLs_hg38.assoc", index = False, sep = "\t")

--- a/scripts/5_ld_clump.sh
+++ b/scripts/5_ld_clump.sh
@@ -2,4 +2,4 @@
 module load igmm/apps/plink/1.90b4
 
 # Command
-plink --bfile output/bed_files/GenOMICC_ISARIC_info_score_0.6_chr6 --clump input/ESR1_cis_eQTLs_hg38_formatted_IDs.assoc --clump-p1 5e-6 --clump-p2 0.05 --clump-r2 0.2 --out output/clumps/ESR1_clumped_r0.2
+plink --bfile output/bed_files/GenOMICC_ISARIC_info_score_0.6_chr6 --clump input/ESR1_ciseQTLs_hg38.assoc --clump-p1 5e-6 --clump-p2 0.05 --clump-r2 0.2 --out output/clumps/ESR1_clumped_r0.2


### PR DESCRIPTION
- This branch was created to add an info score threshold as a nextflow parameter
- Initially, this was hard-set to 0.6, as this was relevant to my approach
- Creating a variable parameter allows for portability to new cohorts that might want to use a different threshold for INFO_SCORE