### PR TITLE
Output bed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dag*
 extracted_data*
 ld_results*
 generate_info_score*
+test_*

--- a/modules/bgen.nf
+++ b/modules/bgen.nf
@@ -69,6 +69,7 @@ process find_exclusion_snps {
 }
 
 process bgen_to_bed {
+    publishDir("$params.OUTDIR/filtered_bed_files")
     label 'moremem'
     label 'qctool_image'
 

--- a/modules/clump.nf
+++ b/modules/clump.nf
@@ -17,6 +17,7 @@ process create_assoc_file {
 
 process ld_clump {
     label 'plink_image'
+    label 'moremem'
     publishDir "$params.OUTDIR/clumps"
 
     input:


### PR DESCRIPTION
Update pipeline to output QC filtered BED files, so that LD scores can be checked on the output from the pipeline.