### PR TITLE
Fix estimands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The configuration for a given run is specified in a run-specific config file, wh
 * `SNPSTATS_CACHE` [ optional, default: `OUTDIR`/info_scores ] : Cache for saving snp stats output from QCtoolv2. This contains the output from the process bgen::generate_info_score(), and includes the following crucial information for every SNP in your `BGEN_FILES`: rsid, info, minor_allele_frequency.
 * `OUTCOME_EXTRA_COVARIATES` [ optional, default: ["Age-Assessment","Genetic-Sex"] ] : Extra covariates to add into estimands file used in TarGene. Current defaults are Age and Sex based on the labels used in the UK BioBank. These should be contained in a list and should also be formatted as Strings. 
 * `ESTIMANDS_ORDERS` [ optional, default: [2] ] : Order of interactions to compute in downstream TarGene run.
-* `ESTIMANDS_TYPE` [ optional, default: ["AIE] ] : Type of estimand for TarGene run. As this pipeline is specifically aimed at looking at interactions between variants, the default is AIE - Average Interaction Effect. These should be contained in a list and should also be formatted as Strings. 
+* `ESTIMANDS_TYPE` [ optional, default: "AIE" ] : Type of estimand for TarGene run. As this pipeline is specifically aimed at looking at interactions between variants, the default is AIE - Average Interaction Effect. These should be a single String. 
 * `EXTRA_TREATMENTS` [ optional, default: [] ] : If there are additional confounder to include in your downstream run, specify them here. These should be contained in a list and should also be formatted as Strings. 
 * `ESTIMANDS_CONFIGURATION_TYPE` [ optional, default: "groups" ] : Type of configuration run for TarGene. See https://targene.github.io/targene-pipeline/stable/examples/interactions/ for more information.
 

--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,7 @@ params.ASB_quality = "High"
 // TARGENE specifications
 params.OUTCOME_EXTRA_COVARIATES = ["Age-Assessment","Genetic-Sex"]
 params.ESTIMANDS_ORDERS = [2]
-params.ESTIMANDS_TYPE = ["AIE"]
+params.ESTIMANDS_TYPE = "AIE"
 params.EXTRA_TREATMENTS = []
 params.ESTIMANDS_CONFIGURATION_TYPE = "groups"
 

--- a/modules/outputs.nf
+++ b/modules/outputs.nf
@@ -111,7 +111,7 @@ process generate_estimands {
         outcome_extra_covariates = ${params.OUTCOME_EXTRA_COVARIATES.collect{"'$it'"}}
         extra_treatments = ${params.EXTRA_TREATMENTS.collect{"'$it'"}}
         estimands_orders = ${params.ESTIMANDS_ORDERS}
-        estimands_type = ${params.ESTIMANDS_TYPE.collect{"'$it'"}}
+        estimands_type = "${params.ESTIMANDS_TYPE}"
         estimands_configuration_type = "${params.ESTIMANDS_CONFIGURATION_TYPE}"
 
         # Final SNPs

--- a/scripts/create_estimands_file.py
+++ b/scripts/create_estimands_file.py
@@ -13,6 +13,7 @@ yaml.add_representer(QuotedString, quoted_presenter)
 
 # Function to convert all strings in a dictionary to a QuotedString
 def quote_strings(obj):
+    """Recursively convert strings in a dictionary or list to QuotedString."""
     if isinstance(obj, str):
         return QuotedString(obj)
     elif isinstance(obj, list):
@@ -21,11 +22,17 @@ def quote_strings(obj):
         return {key: quote_strings(value) for key, value in obj.items()}
     return obj
 
+# Custom Dumper to ensure correct indentation
+class IndentedDumper(yaml.Dumper):
+    """Add indentation where necessary in output YAML."""
+    def increase_indent(self, flow=False, indentless=False):
+        return super(IndentedDumper, self).increase_indent(flow, False)
+
 # TARGENE specifications
 outcome_extra_covariates = ["Age-Assessment","Genetic-Sex"]
 extra_treatments = []
 estimands_orders = [2,3]
-estimands_type = "AIE"
+estimands_type = ["AIE"]
 estimands_configuration_type = "groups"
 
 # Final SNPs
@@ -38,35 +45,24 @@ bqtls = bqtls[bqtls['TF'].isin(transactors.TF.unique())]
 bqtl_dictionary = {key: bqtls.loc[bqtls['TF'] == key, 'SNP'].tolist() for key in bqtls['TF']}
 transactors_dictionary = {key: transactors.loc[transactors['TF'] == key, 'SNP'].tolist() for key in transactors['TF']}
 
-joined = {}
+joined = {key: {'bQTLs': bqtl_dictionary.get(key, []), 'transActors': transactors_dictionary.get(key, [])} for key in bqtl_dictionary}
 
-for key in bqtl_dictionary:
-    joined[key] = {'bQTLs': bqtl_dictionary[key], 'transActors': transactors_dictionary[key]}
+# Construct the YAML data
+estimands_entry = {'orders': estimands_orders, 'type': estimands_type}
 
-# Generate complete dictionary
-if len(extra_treatments) == 0:
-    data = {
-        'type': estimands_configuration_type,
-        'estimands': [
-            {'type': estimands_type, 'orders': estimands_orders}
-        ],
-        'outcome_extra_covariates': outcome_extra_covariates,
-        'variants': joined
-    }
-else:
-    data = {
-        'type': estimands_configuration_type,
-        'estimands': [
-            {'type': estimands_type, 'orders': estimands_orders}
-        ],
-        'outcome_extra_covariates': outcome_extra_covariates,
-        'extra_treatments' : extra_treatments,
-        'variants': joined
-    } 
+data = {
+    'type': estimands_configuration_type,
+    'estimands': [estimands_entry],
+    'outcome_extra_covariates': outcome_extra_covariates,
+    'variants': joined
+}
+
+if extra_treatments:
+    data['extra_treatments'] = extra_treatments
 
 # Ensure quoted strings
 quoted_data = quote_strings(data)
 
-# Write to YAML
+# Write to YAML with correct indentation
 with open('estimands.yaml', 'w') as file:
-    yaml.dump(quoted_data, file, default_flow_style=False, sort_keys=False)
+    yaml.dump(quoted_data, file, default_flow_style=False, sort_keys=False, width=100, indent=2, Dumper=IndentedDumper)


### PR DESCRIPTION
Fix estimands.yaml output so that the format is actually compatible with a targene interaction run. Some indentation/formatting was resulting in an error being thrown downstream by the targene-pipeline in the EstimationInputs() process.