### PR TITLE
Remove duplicate SNPs from ld block removal input file

### DIFF
--- a/modules/outputs.nf
+++ b/modules/outputs.nf
@@ -209,6 +209,7 @@ process create_ld_block_input_file {
         annot_transactors.columns = ["RSID","CHR","POS"] 
 
         final = pd.concat([annot_bqtls, annot_transactors], ignore_index=True)
+	final = final.drop_duplicates(subset = ["RSID"])
         final.to_csv("ld-block-removal-input.csv", index = False)
         """
 }

--- a/modules/outputs.nf
+++ b/modules/outputs.nf
@@ -159,7 +159,7 @@ process create_ld_block_input_file {
         path input_bqtls
 
     output:
-        path "ld-block-removal-input.csv"
+        path "snps.csv"
         path "final_bQTLs.csv"
         path "final_transactors.csv"
 
@@ -210,6 +210,6 @@ process create_ld_block_input_file {
 
         final = pd.concat([annot_bqtls, annot_transactors], ignore_index=True)
 	final = final.drop_duplicates(subset = ["RSID"])
-        final.to_csv("ld-block-removal-input.csv", index = False)
+        final.to_csv("snps.csv", index = False)
         """
 }


### PR DESCRIPTION
Currently, duplicate SNPs were still present in the snps file created for LD block removal pipeline input. This would result in additional jobs running in downstream pipelines and so these need to be removed.