### PR TITLE
change ENTRYPOINT to CMD for better portability

### DIFF
--- a/containers/commandline/Dockerfile
+++ b/containers/commandline/Dockerfile
@@ -5,4 +5,4 @@ FROM ubuntu:latest
 RUN apt-get update && apt-get install -y wget gzip && apt-get clean
 
 # Set the entrypoint to an interactive shell
-ENTRYPOINT ["/bin/bash"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
Error from all of ur RW with the new executor, google batch, failed when trying to launch this container. This commit fixes that error and has been tested.